### PR TITLE
Rename confit to confuse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     # backports on Python < 2.7
     - "[[ $TRAVIS_PYTHON_VERSION == '2.6' ]] && pip install unittest2 || true"
 
-script: nosetests --with-coverage --cover-package=confit
+script: nosetests --with-coverage --cover-package=confuse
 
 # coveralls.io reporting, using https://github.com/coagulant/coveralls-python
 # Only report coverage for one version.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-Confit: painless YAML config files that Just Work
+Confuse: painless YAML config files that Just Work
 =================================================
 
-.. image:: https://travis-ci.org/sampsyo/confit.svg?branch=master
-    :target: https://travis-ci.org/sampsyo/confit
+.. image:: https://travis-ci.org/sampsyo/confuse.svg?branch=master
+    :target: https://travis-ci.org/sampsyo/confuse
 
 .. image:: http://img.shields.io/pypi/v/confuse.svg
     :target: https://pypi.python.org/pypi/confuse
@@ -14,7 +14,7 @@ missing values, fall back to defaults, override config values with
 command-line options, and all that. I think a configuration library
 should be able to handle a lot more for me.
 
-So I'm writing **Confit** to magically take care of defaults, overrides,
+So I'm writing **Confuse** to magically take care of defaults, overrides,
 type checking, command-line integration, human-readable errors, and
 standard OS-specific locations. The configuration files will be based on
 `YAML`_, which is a great syntax for writing down data.
@@ -22,7 +22,7 @@ standard OS-specific locations. The configuration files will be based on
 What It Does
 ------------
 
-Here’s what Confit brings to the table:
+Here’s what Confuse brings to the table:
 
 -  An **utterly sensible API** resembling dictionary-and-list structures
    but providing **transparent validation** without lots of boilerplate
@@ -30,7 +30,7 @@ Here’s what Confit brings to the table:
    number of goats and ensure that it’s an integer.
 
 -  Combine configuration data from **multiple sources**. Using
-   *layering*, Confit allows user-specific configuration to seamlessly
+   *layering*, Confuse allows user-specific configuration to seamlessly
    override system-wide configuration, which in turn overrides built-in
    defaults. An in-package ``config_default.yaml`` can be used to
    provide bottom-layer defaults using the same syntax that users will
@@ -50,24 +50,24 @@ Here’s what Confit brings to the table:
    from the standard library. Use argparse's declarative API to allow
    command-line options to override configured defaults.
 
-Using Confit
+Using Confuse
 ------------
 
-`Confit’s documentation`_ describes its API in detail.
+`Confuse’s documentation`_ describes its API in detail.
 
 Author
 ------
 
-Confit is being developed by `Adrian Sampson`_. It’s not done yet, but
+Confuse is being developed by `Adrian Sampson`_. It’s not done yet, but
 you’re welcome to use it under the terms of the `MIT license`_. I'm
-building Confit to use it with a future version of `beets`_.
+building Confuse to use it with a future version of `beets`_.
 
 .. _ConfigParser: http://docs.python.org/library/configparser.html
 .. _YAML: http://yaml.org/
 .. _optparse: http://docs.python.org/dev/library/optparse.html
 .. _argparse: http://docs.python.org/dev/library/argparse.html
 .. _logging: http://docs.python.org/library/logging.html
-.. _Confit’s documentation: http://confit.readthedocs.org/
+.. _Confuse’s documentation: http://confuse.readthedocs.org/
 .. _Adrian Sampson: https://github.com/sampsyo
 .. _MIT license: http://www.opensource.org/licenses/mit-license.php
 .. _beets: https://github.com/sampsyo/beets

--- a/confuse.py
+++ b/confuse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is part of Confit.
+# This file is part of Confuse.
 # Copyright 2016, Adrian Sampson.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -958,7 +958,7 @@ should be raised when the value is missing.
 class Template(object):
     """A value template for configuration fields.
 
-    The template works like a type and instructs Confit about how to
+    The template works like a type and instructs Confuse about how to
     interpret a deserialized YAML value. This includes type conversions,
     providing a default value, and validating for errors. For example, a
     filepath type might expand tildes and check that the file exists.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,17 +72,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Confit.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Confuse.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Confit.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Confuse.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/Confit"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Confit"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/Confuse"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Confuse"
 	@echo "# devhelp"
 
 epub:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@ extensions = []
 source_suffix = '.rst'
 master_doc = 'index'
 
-project = u'Confit'
+project = u'Confuse'
 copyright = u'2012, Adrian Sampson'
 
 version = '0.1'
@@ -16,4 +16,4 @@ pygments_style = 'sphinx'
 
 html_theme = 'default'
 html_static_path = ['_static']
-htmlhelp_basename = 'Confitdoc'
+htmlhelp_basename = 'Confusedoc'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,19 +1,19 @@
-Confit: Painless Configuration
+Confuse: Painless Configuration
 ==============================
 
-`Confit`_ (*con-FEE*) is a straightforward, full-featured configuration system
+`Confuse`_ is a straightforward, full-featured configuration system
 for Python.
 
-.. _Confit: https://github.com/sampsyo/confit
+.. _Confuse: https://github.com/sampsyo/confuse
 
 
-Using Confit
+Using Confuse
 ------------
 
 Set up your Configuration object, which provides unified access to
 all of your application’s config settings::
 
-    config = confit.Configuration('MyGreatApp', __name__)
+    config = confuse.Configuration('MyGreatApp', __name__)
 
 The first parameter is required; it’s the name of your application that
 will be used to search the system for config files. The second parameter
@@ -39,19 +39,19 @@ pass that type to ``get()``::
 
     int_value = config['number_of_goats'].get(int)
 
-This way, Confit will either give you an integer or raise a
+This way, Confuse will either give you an integer or raise a
 ``ConfigTypeError`` if the user has messed up the configuration. You’re
 safe to assume after this call that ``int_value`` has the right type. If
-the key doesn’t exist in any configuration file, Confit will raise a
+the key doesn’t exist in any configuration file, Confuse will raise a
 ``NotFoundError``. Together, catching these exceptions (both subclasses
-of ``confit.ConfigError``) lets you painlessly validate the user’s
+of ``confuse.ConfigError``) lets you painlessly validate the user’s
 configuration as you go.
 
 
 View Theory
 -----------
 
-The Confit API is based on the concept of *views*. You can think of a
+The Confuse API is based on the concept of *views*. You can think of a
 view as a *place to look* in a config file: for example, one view might
 say “get the value for key ``number_of_goats``”. Another might say “get
 the value at index 8 inside the sequence for key ``animal_counts``”. To
@@ -77,8 +77,8 @@ the user’s config rates them a 10, then clearly
 ``config['deliciousness']['carrots'].get()`` should return 10. But what
 if the two data sources have different sets of vegetables? If the user
 provides a value for broccoli and zucchini but not carrots, should
-carrots have a default deliciousness value of 8 or should Confit just
-throw an exception? With Confit’s views, the application gets to decide.
+carrots have a default deliciousness value of 8 or should Confuse just
+throw an exception? With Confuse’s views, the application gets to decide.
 
 The above expression, ``config['deliciousness']['carrots'].get()``,
 returns 10 (falling back on the default). However, you can also write
@@ -96,7 +96,7 @@ Validation
 
 We saw above that you can easily assert that a configuration value has a
 certain type by passing that type to ``get()``. But sometimes you need
-to do more than just type checking. For this reason, Confit provides a
+to do more than just type checking. For this reason, Confuse provides a
 few methods on views that perform fancier validation or even
 conversion:
 
@@ -138,7 +138,7 @@ configuration file should override those from a system-wide config,
 command-line options should take priority over all configuration files.
 
 You can use the `argparse`_ and `optparse`_ modules from the standard
-library with Confit to accomplish this. Just call the ``set_args``
+library with Confuse to accomplish this. Just call the ``set_args``
 method on any view and pass in the object returned by the command-line
 parsing library. Values from the command-line option namespace object
 will be added to the overlay for the view in question. For example, with
@@ -157,7 +157,7 @@ source in your configuration. The key associated with each option in the
 parser will become a key available in your configuration. For example,
 consider this argparse script::
 
-    config = confit.Configuration('myapp')
+    config = confuse.Configuration('myapp')
     parser = argparse.ArgumentParser()
     parser.add_argument('--foo', help='a parameter')
     args = parser.parse_args()
@@ -173,7 +173,7 @@ This will allow the user to override the configured value for key
 
 Note that, while you can use the full power of your favorite
 command-line parsing library, you'll probably want to avoid specifying
-defaults in your argparse or optparse setup. This way, Confit can use
+defaults in your argparse or optparse setup. This way, Confuse can use
 other configuration sources---possibly your
 ``config_default.yaml``---to fill in values for unspecified
 command-line switches. Otherwise, the argparse/optparse default value
@@ -183,9 +183,9 @@ will hide options configured elsewhere.
 Search Paths
 ------------
 
-Confit looks in a number of locations for your application's
+Confuse looks in a number of locations for your application's
 configurations. The locations are determined by the platform. For each
-platform, Confit has a list of directories in which it looks for a
+platform, Confuse has a list of directories in which it looks for a
 directory named after the application. For example, the first search
 location on Unix-y systems is ``$XDG_CONFIG_HOME/AppName`` for an
 application called ``AppName``.
@@ -206,19 +206,19 @@ environment variable is ``APPNAMEDIR``.
 Your Application Directory
 --------------------------
 
-Confit provides a simple helper, ``Configuration.config_dir()``, that
+Confuse provides a simple helper, ``Configuration.config_dir()``, that
 gives you a directory used to store your application's configuration. If
 a configuration file exists in any of the searched locations, then the
 highest-priority directory containing a config file is used. Otherwise,
 a directory is created for you and returned. So you can always expect
 this method to give you a directory that actually exists.
 
-As an example, you may want to migrate a user's settings to Confit from
+As an example, you may want to migrate a user's settings to Confuse from
 an older configuration system such as `ConfigParser`_. Just do something
 like this::
 
     config_filename = os.path.join(config.config_dir(),
-                                   confit.CONFIG_FILENAME)
+                                   confuse.CONFIG_FILENAME)
     with open(config_filename, 'w') as f:
         yaml.dump(migrated_config, f)
 
@@ -234,7 +234,7 @@ the program to change a setting for the current execution only. Or the
 program might need to add a *derived* configuration value that the user
 doesn't specify.
 
-To facilitate this, Confit lets you *assign* to view objects using
+To facilitate this, Confuse lets you *assign* to view objects using
 ordinary Python assignment. Assignment will add an overlay source that
 precedes all other configuration sources in priority. Here's an example
 of programmatically setting a configuration value based on a ``DEBUG``
@@ -260,7 +260,7 @@ be overridden by previously-loaded configuration files.
 YAML Tweaks
 -----------
 
-Confit uses the `PyYAML`_ module to parse YAML configuration files. However, it
+Confuse uses the `PyYAML`_ module to parse YAML configuration files. However, it
 deviates very slightly from the official YAML specification to provide a few
 niceties suited to human-written configuration files. Those tweaks are:
 
@@ -303,7 +303,7 @@ pass configuration from call to call.
 
 To use global configuration, consider creating a configuration object in
 a well-known module (say, the root of a package). But since this object
-will be initialized at module load time, Confit provides a `LazyConfig`
+will be initialized at module load time, Confuse provides a `LazyConfig`
 object that loads your configuration files on demand instead of when the
 object is constructed. (Doing complicated stuff like parsing YAML at
 module load time is generally considered a Bad Idea.)

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,26 +1,26 @@
-"""An example application using Confit for configuration."""
+"""An example application using Confuse for configuration."""
 from __future__ import print_function
 from __future__ import unicode_literals
-import confit
+import confuse
 import argparse
 
 template = {
-    'library': confit.Filename(),
-    'import_write': confit.OneOf([bool, 'ask', 'skip']),
-    'ignore': confit.StrSeq(),
+    'library': confuse.Filename(),
+    'import_write': confuse.OneOf([bool, 'ask', 'skip']),
+    'ignore': confuse.StrSeq(),
     'plugins': list,
 
     'paths': {
-        'directory': confit.Filename(),
-        'default': confit.Filename(relative_to='directory'),
+        'directory': confuse.Filename(),
+        'default': confuse.Filename(relative_to='directory'),
     }
 }
 
-config = confit.LazyConfig('ConfitExample', __name__)
+config = confuse.LazyConfig('ConfuseExample', __name__)
 
 
 def main():
-    parser = argparse.ArgumentParser(description='example Confit program')
+    parser = argparse.ArgumentParser(description='example Confuse program')
     parser.add_argument('--library', '-l', dest='library', metavar='LIBPATH',
                         help='library database file')
     parser.add_argument('--directory', '-d', dest='directory',

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,14 @@ setup(
     description='painless YAML configuration',
     author='Adrian Sampson',
     author_email='adrian@radbox.org',
-    url='https://github.com/sampsyo/confit',
+    url='https://github.com/sampsyo/confuse',
     license='MIT',
     platforms='ALL',
     long_description=_read("README.rst"),
 
     install_requires=reqs,
 
-    py_modules=['confit'],
+    py_modules=['confuse'],
 
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info[0] <= 2 and sys.version_info[1] < 7:
 
 setup(
     name='confuse',
-    version='0.3.1',
+    version='0.4.0',
     description='painless YAML configuration',
     author='Adrian Sampson',
     author_email='adrian@radbox.org',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
-import confit
+import confuse
 import tempfile
 import shutil
 import os
@@ -12,7 +12,7 @@ except ImportError:
 
 
 def _root(*sources):
-    return confit.RootView([confit.ConfigSource.of(s) for s in sources])
+    return confuse.RootView([confuse.ConfigSource.of(s) for s in sources])
 
 
 class TempDir(object):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,11 +1,11 @@
-import confit
+import confuse
 import argparse
 import optparse
 from . import unittest
 
 class ArgparseTest(unittest.TestCase):
     def setUp(self):
-        self.config = confit.Configuration('test', read=False)
+        self.config = confuse.Configuration('test', read=False)
         self.parser = argparse.ArgumentParser()
 
     def _parse(self, args):
@@ -25,7 +25,7 @@ class ArgparseTest(unittest.TestCase):
     def test_missing_optional_argument_not_included(self):
         self.parser.add_argument('--foo', metavar='BAR')
         self._parse('')
-        with self.assertRaises(confit.NotFoundError):
+        with self.assertRaises(confuse.NotFoundError):
             self.config['foo'].get()
 
     def test_argument_overrides_default(self):
@@ -37,7 +37,7 @@ class ArgparseTest(unittest.TestCase):
 
 class OptparseTest(unittest.TestCase):
     def setUp(self):
-        self.config = confit.Configuration('test', read=False)
+        self.config = confuse.Configuration('test', read=False)
         self.parser = optparse.OptionParser()
 
     def _parse(self, args):
@@ -57,7 +57,7 @@ class OptparseTest(unittest.TestCase):
     def test_missing_optional_argument_not_included(self):
         self.parser.add_option('--foo', metavar='BAR')
         self._parse('')
-        with self.assertRaises(confit.NotFoundError):
+        with self.assertRaises(confuse.NotFoundError):
             self.config['foo'].get()
 
     def test_argument_overrides_default(self):
@@ -73,7 +73,7 @@ class Namespace(object):
 
 class GenericNamespaceTest(unittest.TestCase):
     def setUp(self):
-        self.config = confit.Configuration('test', read=False)
+        self.config = confuse.Configuration('test', read=False)
 
     def test_value_added_to_root(self):
         self.config.set_args(Namespace(foo='bar'))

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -1,40 +1,40 @@
-import confit
+import confuse
 import textwrap
 from . import unittest, _root
 
 
 class PrettyDumpTest(unittest.TestCase):
     def test_dump_null(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': None})
         yaml = config.dump().strip()
         self.assertEqual(yaml, 'foo:')
 
     def test_dump_true(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': True})
         yaml = config.dump().strip()
         self.assertEqual(yaml, 'foo: yes')
 
     def test_dump_false(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': False})
         yaml = config.dump().strip()
         self.assertEqual(yaml, 'foo: no')
 
     def test_dump_short_list(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': ['bar', 'baz']})
         yaml = config.dump().strip()
         self.assertEqual(yaml, 'foo: [bar, baz]')
 
     def test_dump_ordered_dict(self):
-        odict = confit.OrderedDict()
+        odict = confuse.OrderedDict()
         odict['foo'] = 'bar'
         odict['bar'] = 'baz'
         odict['baz'] = 'qux'
 
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'key': odict})
         yaml = config.dump().strip()
         self.assertEqual(yaml, textwrap.dedent("""
@@ -45,7 +45,7 @@ class PrettyDumpTest(unittest.TestCase):
         """).strip())
 
     def test_dump_sans_defaults(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': 'bar'})
         config.sources[0].default = True
         config.add({'baz': 'qux'})
@@ -77,21 +77,21 @@ class RedactTest(unittest.TestCase):
         self.assertEqual(data, {'foo': 'bar'})
 
     def test_dump_redacted(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': 'bar'})
         config['foo'].redact = True
         yaml = config.dump(redact=True).strip()
         self.assertEqual(yaml, 'foo: REDACTED')
 
     def test_dump_unredacted(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': 'bar'})
         config['foo'].redact = True
         yaml = config.dump(redact=False).strip()
         self.assertEqual(yaml, 'foo: bar')
 
     def test_dump_redacted_sans_defaults(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         config.add({'foo': 'bar'})
         config.sources[0].default = True
         config.add({'baz': 'qux'})

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -1,4 +1,4 @@
-import confit
+import confuse
 import ntpath
 import os
 import platform
@@ -48,23 +48,23 @@ class LinuxTestCases(FakeSystem):
     SYS_NAME = 'Linux'
 
     def test_both_xdg_and_fallback_dirs(self):
-        self.assertEqual(confit.config_dirs(),
+        self.assertEqual(confuse.config_dirs(),
             ['/home/test/.config', '/home/test/xdgconfig'])
 
     def test_fallback_only(self):
         del os.environ['XDG_CONFIG_HOME']
-        self.assertEqual(confit.config_dirs(), ['/home/test/.config'])
+        self.assertEqual(confuse.config_dirs(), ['/home/test/.config'])
 
     def test_xdg_matching_fallback_not_duplicated(self):
         os.environ['XDG_CONFIG_HOME'] = '~/.config'
-        self.assertEqual(confit.config_dirs(), ['/home/test/.config'])
+        self.assertEqual(confuse.config_dirs(), ['/home/test/.config'])
 
 
 class OSXTestCases(FakeSystem):
     SYS_NAME = 'Darwin'
 
     def test_mac_dirs(self):
-        self.assertEqual(confit.config_dirs(),
+        self.assertEqual(confuse.config_dirs(),
             ['/Users/test/Library/Application Support', '/Users/test/.config'])
 
 
@@ -72,31 +72,31 @@ class WindowsTestCases(FakeSystem):
     SYS_NAME = 'Windows'
 
     def test_dir_from_environ(self):
-        self.assertEqual(confit.config_dirs(),
+        self.assertEqual(confuse.config_dirs(),
             ['C:\\Users\\test\\AppData\\Roaming',
             'C:\\Users\\test\\winconfig'])
 
     def test_fallback_dir(self):
         del os.environ['APPDATA']
-        self.assertEqual(confit.config_dirs(),
+        self.assertEqual(confuse.config_dirs(),
             ['C:\\Users\\test\\AppData\\Roaming'])
 
 
 class ConfigFilenamesTest(unittest.TestCase):
     def setUp(self):
-        self._old = os.path.isfile, confit.load_yaml
-        os.path.isfile, confit.load_yaml = lambda x: True, lambda x: {}
+        self._old = os.path.isfile, confuse.load_yaml
+        os.path.isfile, confuse.load_yaml = lambda x: True, lambda x: {}
 
     def tearDown(self):
-        confit.load_yaml, os.path.isfile = self._old
+        confuse.load_yaml, os.path.isfile = self._old
 
     def test_no_sources_when_files_missing(self):
-        config = confit.Configuration('myapp', read=False)
+        config = confuse.Configuration('myapp', read=False)
         filenames = [s.filename for s in config.sources]
         self.assertEqual(filenames, [])
 
     def test_search_package(self):
-        config = confit.Configuration('myapp', __name__, read=False)
+        config = confuse.Configuration('myapp', __name__, read=False)
         config._add_default_source()
 
         for source in config.sources:
@@ -118,7 +118,7 @@ class EnvVarTest(FakeSystem):
 
     def setUp(self):
         super(EnvVarTest, self).setUp()
-        self.config = confit.Configuration('myapp', read=False)
+        self.config = confuse.Configuration('myapp', read=False)
         os.environ['MYAPPDIR'] = self.home  # use the tmp home as a config dir
 
     def test_env_var_name(self):
@@ -153,7 +153,7 @@ class PrimaryConfigDirTest(FakeSystem):
             os.path.join = self.join
             os.makedirs, self._makedirs = self.makedirs, os.makedirs
 
-        self.config = confit.Configuration('test', read=False)
+        self.config = confuse.Configuration('test', read=False)
 
     def tearDown(self):
         super(PrimaryConfigDirTest, self).tearDown()
@@ -170,14 +170,14 @@ class PrimaryConfigDirTest(FakeSystem):
     def test_return_existing_dir(self):
         path = os.path.join(self.home, 'xdgconfig', 'test')
         os.makedirs(path)
-        _touch(os.path.join(path, confit.CONFIG_FILENAME))
+        _touch(os.path.join(path, confuse.CONFIG_FILENAME))
         self.assertEqual(self.config.config_dir(), path)
 
     def test_do_not_create_dir_if_lower_priority_exists(self):
         path1 = os.path.join(self.home, 'xdgconfig', 'test')
         path2 = os.path.join(self.home, '.config', 'test')
         os.makedirs(path2)
-        _touch(os.path.join(path2, confit.CONFIG_FILENAME))
+        _touch(os.path.join(path2, confuse.CONFIG_FILENAME))
         assert not os.path.exists(path1)
         assert os.path.exists(path2)
 

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -1,4 +1,4 @@
-import confit
+import confuse
 import os
 import collections
 from . import _root, unittest
@@ -7,23 +7,23 @@ from . import _root, unittest
 class ValidConfigTest(unittest.TestCase):
     def test_validate_simple_dict(self):
         config = _root({'foo': 5})
-        valid = config.get({'foo': confit.Integer()})
+        valid = config.get({'foo': confuse.Integer()})
         self.assertEqual(valid['foo'], 5)
 
     def test_default_value(self):
         config = _root({})
-        valid = config.get({'foo': confit.Integer(8)})
+        valid = config.get({'foo': confuse.Integer(8)})
         self.assertEqual(valid['foo'], 8)
 
     def test_undeclared_key_raises_keyerror(self):
         config = _root({'foo': 5})
-        valid = config.get({'foo': confit.Integer()})
+        valid = config.get({'foo': confuse.Integer()})
         with self.assertRaises(KeyError):
             valid['bar']
 
     def test_undeclared_key_ignored_from_input(self):
         config = _root({'foo': 5, 'bar': 6})
-        valid = config.get({'foo': confit.Integer()})
+        valid = config.get({'foo': confuse.Integer()})
         with self.assertRaises(KeyError):
             valid['bar']
 
@@ -39,27 +39,27 @@ class ValidConfigTest(unittest.TestCase):
 
     def test_attribute_access(self):
         config = _root({'foo': 5})
-        valid = config.get({'foo': confit.Integer()})
+        valid = config.get({'foo': confuse.Integer()})
         self.assertEqual(valid.foo, 5)
 
     def test_missing_required_value_raises_error_on_validate(self):
         config = _root({})
-        with self.assertRaises(confit.NotFoundError):
-            config.get({'foo': confit.Integer()})
+        with self.assertRaises(confuse.NotFoundError):
+            config.get({'foo': confuse.Integer()})
 
     def test_none_as_default(self):
         config = _root({})
-        valid = config.get({'foo': confit.Integer(None)})
+        valid = config.get({'foo': confuse.Integer(None)})
         self.assertIsNone(valid['foo'])
 
     def test_wrong_type_raises_error_on_validate(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.ConfigTypeError):
-            config.get({'foo': confit.Integer()})
+        with self.assertRaises(confuse.ConfigTypeError):
+            config.get({'foo': confuse.Integer()})
 
     def test_validate_individual_value(self):
         config = _root({'foo': 5})
-        valid = config['foo'].get(confit.Integer())
+        valid = config['foo'].get(confuse.Integer())
         self.assertEqual(valid, 5)
 
     def test_nested_dict_template(self):
@@ -67,7 +67,7 @@ class ValidConfigTest(unittest.TestCase):
             'foo': {'bar': 9},
         })
         valid = config.get({
-            'foo': {'bar': confit.Integer()},
+            'foo': {'bar': confuse.Integer()},
         })
         self.assertEqual(valid['foo']['bar'], 9)
 
@@ -76,123 +76,123 @@ class ValidConfigTest(unittest.TestCase):
             'foo': {'bar': 8},
         })
         valid = config.get({
-            'foo': {'bar': confit.Integer()},
+            'foo': {'bar': confuse.Integer()},
         })
         self.assertEqual(valid.foo.bar, 8)
 
 
 class AsTemplateTest(unittest.TestCase):
     def test_plain_int_as_template(self):
-        typ = confit.as_template(int)
-        self.assertIsInstance(typ, confit.Integer)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(int)
+        self.assertIsInstance(typ, confuse.Integer)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_concrete_int_as_template(self):
-        typ = confit.as_template(2)
-        self.assertIsInstance(typ, confit.Integer)
+        typ = confuse.as_template(2)
+        self.assertIsInstance(typ, confuse.Integer)
         self.assertEqual(typ.default, 2)
 
     def test_plain_string_as_template(self):
-        typ = confit.as_template(str)
-        self.assertIsInstance(typ, confit.String)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(str)
+        self.assertIsInstance(typ, confuse.String)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_concrete_string_as_template(self):
-        typ = confit.as_template('foo')
-        self.assertIsInstance(typ, confit.String)
+        typ = confuse.as_template('foo')
+        self.assertIsInstance(typ, confuse.String)
         self.assertEqual(typ.default, 'foo')
 
-    @unittest.skipIf(confit.PY3, "unicode only present in Python 2")
+    @unittest.skipIf(confuse.PY3, "unicode only present in Python 2")
     def test_unicode_type_as_template(self):
-        typ = confit.as_template(unicode)
-        self.assertIsInstance(typ, confit.String)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(unicode)
+        self.assertIsInstance(typ, confuse.String)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
-    @unittest.skipIf(confit.PY3, "basestring only present in Python 2")
+    @unittest.skipIf(confuse.PY3, "basestring only present in Python 2")
     def test_basestring_as_template(self):
-        typ = confit.as_template(basestring)
-        self.assertIsInstance(typ, confit.String)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(basestring)
+        self.assertIsInstance(typ, confuse.String)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_dict_as_template(self):
-        typ = confit.as_template({'key': 9})
-        self.assertIsInstance(typ, confit.MappingTemplate)
-        self.assertIsInstance(typ.subtemplates['key'], confit.Integer)
+        typ = confuse.as_template({'key': 9})
+        self.assertIsInstance(typ, confuse.MappingTemplate)
+        self.assertIsInstance(typ.subtemplates['key'], confuse.Integer)
         self.assertEqual(typ.subtemplates['key'].default, 9)
 
     def test_nested_dict_as_template(self):
-        typ = confit.as_template({'outer': {'inner': 2}})
-        self.assertIsInstance(typ, confit.MappingTemplate)
+        typ = confuse.as_template({'outer': {'inner': 2}})
+        self.assertIsInstance(typ, confuse.MappingTemplate)
         self.assertIsInstance(typ.subtemplates['outer'],
-                              confit.MappingTemplate)
+                              confuse.MappingTemplate)
         self.assertIsInstance(typ.subtemplates['outer'].subtemplates['inner'],
-                              confit.Integer)
+                              confuse.Integer)
         self.assertEqual(typ.subtemplates['outer'].subtemplates['inner']
                          .default, 2)
 
     def test_list_as_template(self):
-        typ = confit.as_template(list())
-        self.assertIsInstance(typ, confit.OneOf)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(list())
+        self.assertIsInstance(typ, confuse.OneOf)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_set_as_template(self):
-        typ = confit.as_template(set())
-        self.assertIsInstance(typ, confit.Choice)
+        typ = confuse.as_template(set())
+        self.assertIsInstance(typ, confuse.Choice)
 
     def test_float_type_as_tempalte(self):
-        typ = confit.as_template(float)
-        self.assertIsInstance(typ, confit.Number)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(float)
+        self.assertIsInstance(typ, confuse.Number)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_none_as_template(self):
-        typ = confit.as_template(None)
-        self.assertIs(type(typ), confit.Template)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        typ = confuse.as_template(None)
+        self.assertIs(type(typ), confuse.Template)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_dict_type_as_template(self):
-        typ = confit.as_template(dict)
-        self.assertIsInstance(typ, confit.TypeTemplate)
+        typ = confuse.as_template(dict)
+        self.assertIsInstance(typ, confuse.TypeTemplate)
         self.assertEqual(typ.typ, collections.Mapping)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_list_type_as_template(self):
-        typ = confit.as_template(list)
-        self.assertIsInstance(typ, confit.TypeTemplate)
+        typ = confuse.as_template(list)
+        self.assertIsInstance(typ, confuse.TypeTemplate)
         self.assertEqual(typ.typ, collections.Sequence)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_set_type_as_template(self):
-        typ = confit.as_template(set)
-        self.assertIsInstance(typ, confit.TypeTemplate)
+        typ = confuse.as_template(set)
+        self.assertIsInstance(typ, confuse.TypeTemplate)
         self.assertEqual(typ.typ, set)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
     def test_other_type_as_template(self):
         class MyClass(object):
             pass
-        typ = confit.as_template(MyClass)
-        self.assertIsInstance(typ, confit.TypeTemplate)
+        typ = confuse.as_template(MyClass)
+        self.assertIsInstance(typ, confuse.TypeTemplate)
         self.assertEqual(typ.typ, MyClass)
-        self.assertEqual(typ.default, confit.REQUIRED)
+        self.assertEqual(typ.default, confuse.REQUIRED)
 
 
 class StringTemplateTest(unittest.TestCase):
     def test_validate_string(self):
         config = _root({'foo': 'bar'})
-        valid = config.get({'foo': confit.String()})
+        valid = config.get({'foo': confuse.String()})
         self.assertEqual(valid['foo'], 'bar')
 
     def test_string_default_value(self):
         config = _root({})
-        valid = config.get({'foo': confit.String('baz')})
+        valid = config.get({'foo': confuse.String('baz')})
         self.assertEqual(valid['foo'], 'baz')
 
     def test_pattern_matching(self):
         config = _root({'foo': 'bar', 'baz': 'zab'})
-        valid = config.get({'foo': confit.String(pattern='^ba.$')})
+        valid = config.get({'foo': confuse.String(pattern='^ba.$')})
         self.assertEqual(valid['foo'], 'bar')
-        with self.assertRaises(confit.ConfigValueError):
-            config.get({'baz': confit.String(pattern='!')})
+        with self.assertRaises(confuse.ConfigValueError):
+            config.get({'baz': confuse.String(pattern='!')})
 
     def test_string_template_shortcut(self):
         config = _root({'foo': 'bar'})
@@ -206,128 +206,128 @@ class StringTemplateTest(unittest.TestCase):
 
     def test_check_string_type(self):
         config = _root({'foo': 5})
-        with self.assertRaises(confit.ConfigTypeError):
-            config.get({'foo': confit.String()})
+        with self.assertRaises(confuse.ConfigTypeError):
+            config.get({'foo': confuse.String()})
 
 
 class NumberTest(unittest.TestCase):
     def test_validate_int_as_number(self):
         config = _root({'foo': 2})
-        valid = config['foo'].get(confit.Number())
+        valid = config['foo'].get(confuse.Number())
         self.assertIsInstance(valid, int)
         self.assertEqual(valid, 2)
 
     def test_validate_float_as_number(self):
         config = _root({'foo': 3.0})
-        valid = config['foo'].get(confit.Number())
+        valid = config['foo'].get(confuse.Number())
         self.assertIsInstance(valid, float)
         self.assertEqual(valid, 3.0)
 
     def test_validate_string_as_number(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.ConfigTypeError):
-            config['foo'].get(confit.Number())
+        with self.assertRaises(confuse.ConfigTypeError):
+            config['foo'].get(confuse.Number())
 
 
 class ChoiceTest(unittest.TestCase):
     def test_validate_good_choice_in_list(self):
         config = _root({'foo': 2})
-        valid = config['foo'].get(confit.Choice([1, 2, 4, 8, 16]))
+        valid = config['foo'].get(confuse.Choice([1, 2, 4, 8, 16]))
         self.assertEqual(valid, 2)
 
     def test_validate_bad_choice_in_list(self):
         config = _root({'foo': 3})
-        with self.assertRaises(confit.ConfigValueError):
-            config['foo'].get(confit.Choice([1, 2, 4, 8, 16]))
+        with self.assertRaises(confuse.ConfigValueError):
+            config['foo'].get(confuse.Choice([1, 2, 4, 8, 16]))
 
     def test_validate_good_choice_in_dict(self):
         config = _root({'foo': 2})
-        valid = config['foo'].get(confit.Choice({2: 'two', 4: 'four'}))
+        valid = config['foo'].get(confuse.Choice({2: 'two', 4: 'four'}))
         self.assertEqual(valid, 'two')
 
     def test_validate_bad_choice_in_dict(self):
         config = _root({'foo': 3})
-        with self.assertRaises(confit.ConfigValueError):
-            config['foo'].get(confit.Choice({2: 'two', 4: 'four'}))
+        with self.assertRaises(confuse.ConfigValueError):
+            config['foo'].get(confuse.Choice({2: 'two', 4: 'four'}))
 
 
 class OneOfTest(unittest.TestCase):
     def test_default_value(self):
         config = _root({})
-        valid = config['foo'].get(confit.OneOf([], default='bar'))
+        valid = config['foo'].get(confuse.OneOf([], default='bar'))
         self.assertEqual(valid, 'bar')
 
     def test_validate_good_choice_in_list(self):
         config = _root({'foo': 2})
-        valid = config['foo'].get(confit.OneOf([
-            confit.String(),
-            confit.Integer(),
+        valid = config['foo'].get(confuse.OneOf([
+            confuse.String(),
+            confuse.Integer(),
         ]))
         self.assertEqual(valid, 2)
 
     def test_validate_first_good_choice_in_list(self):
         config = _root({'foo': 3.14})
-        valid = config['foo'].get(confit.OneOf([
-            confit.Integer(),
-            confit.Number(),
+        valid = config['foo'].get(confuse.OneOf([
+            confuse.Integer(),
+            confuse.Number(),
         ]))
         self.assertEqual(valid, 3)
 
     def test_validate_no_choice_in_list(self):
         config = _root({'foo': None})
-        with self.assertRaises(confit.ConfigValueError):
-            config['foo'].get(confit.OneOf([
-                confit.String(),
-                confit.Integer(),
+        with self.assertRaises(confuse.ConfigValueError):
+            config['foo'].get(confuse.OneOf([
+                confuse.String(),
+                confuse.Integer(),
             ]))
 
     def test_validate_bad_template(self):
         class BadTemplate(object):
             pass
         config = _root({})
-        with self.assertRaises(confit.ConfigTemplateError):
-            config.get(confit.OneOf([BadTemplate()]))
+        with self.assertRaises(confuse.ConfigTemplateError):
+            config.get(confuse.OneOf([BadTemplate()]))
         del BadTemplate
 
 
 class StrSeqTest(unittest.TestCase):
     def test_string_list(self):
         config = _root({'foo': ['bar', 'baz']})
-        valid = config['foo'].get(confit.StrSeq())
+        valid = config['foo'].get(confuse.StrSeq())
         self.assertEqual(valid, ['bar', 'baz'])
 
     def test_string_tuple(self):
         config = _root({'foo': ('bar', 'baz')})
-        valid = config['foo'].get(confit.StrSeq())
+        valid = config['foo'].get(confuse.StrSeq())
         self.assertEqual(valid, ['bar', 'baz'])
 
     def test_whitespace_separated_string(self):
         config = _root({'foo': 'bar   baz'})
-        valid = config['foo'].get(confit.StrSeq())
+        valid = config['foo'].get(confuse.StrSeq())
         self.assertEqual(valid, ['bar', 'baz'])
 
     def test_invalid_type(self):
         config = _root({'foo': 9})
-        with self.assertRaises(confit.ConfigTypeError):
-            config['foo'].get(confit.StrSeq())
+        with self.assertRaises(confuse.ConfigTypeError):
+            config['foo'].get(confuse.StrSeq())
 
     def test_invalid_sequence_type(self):
         config = _root({'foo': ['bar', 2126]})
-        with self.assertRaises(confit.ConfigTypeError):
-            config['foo'].get(confit.StrSeq())
+        with self.assertRaises(confuse.ConfigTypeError):
+            config['foo'].get(confuse.StrSeq())
 
 
 class FilenameTest(unittest.TestCase):
     def test_filename_relative_to_working_dir(self):
         config = _root({'foo': 'bar'})
-        valid = config['foo'].get(confit.Filename(cwd='/dev/null'))
+        valid = config['foo'].get(confuse.Filename(cwd='/dev/null'))
         self.assertEqual(valid, os.path.realpath('/dev/null/bar'))
 
     def test_filename_relative_to_sibling(self):
         config = _root({'foo': '/', 'bar': 'baz'})
         valid = config.get({
-            'foo': confit.Filename(),
-            'bar': confit.Filename(relative_to='foo')
+            'foo': confuse.Filename(),
+            'bar': confuse.Filename(relative_to='foo')
         })
         self.assertEqual(valid.foo, os.path.realpath('/'))
         self.assertEqual(valid.bar, os.path.realpath('/baz'))
@@ -335,100 +335,100 @@ class FilenameTest(unittest.TestCase):
     def test_filename_working_dir_overrides_sibling(self):
         config = _root({'foo': 'bar'})
         valid = config.get({
-            'foo': confit.Filename(cwd='/dev/null', relative_to='baz')
+            'foo': confuse.Filename(cwd='/dev/null', relative_to='baz')
         })
         self.assertEqual(valid.foo, os.path.realpath('/dev/null/bar'))
 
     def test_filename_relative_to_sibling_with_recursion(self):
         config = _root({'foo': '/', 'bar': 'r', 'baz': 'z'})
-        with self.assertRaises(confit.ConfigTemplateError):
+        with self.assertRaises(confuse.ConfigTemplateError):
             config.get({
-                'foo': confit.Filename(relative_to='bar'),
-                'bar': confit.Filename(relative_to='baz'),
-                'baz': confit.Filename(relative_to='foo')
+                'foo': confuse.Filename(relative_to='bar'),
+                'bar': confuse.Filename(relative_to='baz'),
+                'baz': confuse.Filename(relative_to='foo')
             })
 
     def test_filename_relative_to_self(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.ConfigTemplateError):
+        with self.assertRaises(confuse.ConfigTemplateError):
             config.get({
-                'foo': confit.Filename(relative_to='foo')
+                'foo': confuse.Filename(relative_to='foo')
             })
 
     def test_filename_relative_to_sibling_needs_siblings(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.ConfigTemplateError):
-            config['foo'].get(confit.Filename(relative_to='bar'))
+        with self.assertRaises(confuse.ConfigTemplateError):
+            config['foo'].get(confuse.Filename(relative_to='bar'))
 
     def test_filename_relative_to_sibling_needs_template(self):
         config = _root({'foo': '/', 'bar': 'baz'})
-        with self.assertRaises(confit.ConfigTemplateError):
+        with self.assertRaises(confuse.ConfigTemplateError):
             config.get({
-                'bar': confit.Filename(relative_to='foo')
+                'bar': confuse.Filename(relative_to='foo')
             })
 
     def test_filename_with_non_file_source(self):
         config = _root({'foo': 'foo/bar'})
-        valid = config['foo'].get(confit.Filename())
+        valid = config['foo'].get(confuse.Filename())
         self.assertEqual(valid, os.path.join(os.getcwd(), 'foo', 'bar'))
 
     def test_filename_with_file_source(self):
-        source = confit.ConfigSource({'foo': 'foo/bar'},
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
                                      filename='/baz/config.yaml')
         config = _root(source)
         config.config_dir = lambda: '/config/path'
-        valid = config['foo'].get(confit.Filename())
+        valid = config['foo'].get(confuse.Filename())
         self.assertEqual(valid, os.path.realpath('/config/path/foo/bar'))
 
     def test_filename_with_default_source(self):
-        source = confit.ConfigSource({'foo': 'foo/bar'},
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
                                      filename='/baz/config.yaml',
                                      default=True)
         config = _root(source)
         config.config_dir = lambda: '/config/path'
-        valid = config['foo'].get(confit.Filename())
+        valid = config['foo'].get(confuse.Filename())
         self.assertEqual(valid, os.path.realpath('/config/path/foo/bar'))
 
     def test_filename_wrong_type(self):
         config = _root({'foo': 8})
-        with self.assertRaises(confit.ConfigTypeError):
-            config['foo'].get(confit.Filename())
+        with self.assertRaises(confuse.ConfigTypeError):
+            config['foo'].get(confuse.Filename())
 
 
 class BaseTemplateTest(unittest.TestCase):
     def test_base_template_accepts_any_value(self):
         config = _root({'foo': 4.2})
-        valid = config['foo'].get(confit.Template())
+        valid = config['foo'].get(confuse.Template())
         self.assertEqual(valid, 4.2)
 
     def test_base_template_required(self):
         config = _root({})
-        with self.assertRaises(confit.NotFoundError):
-            config['foo'].get(confit.Template())
+        with self.assertRaises(confuse.NotFoundError):
+            config['foo'].get(confuse.Template())
 
     def test_base_template_with_default(self):
         config = _root({})
-        valid = config['foo'].get(confit.Template('bar'))
+        valid = config['foo'].get(confuse.Template('bar'))
         self.assertEqual(valid, 'bar')
 
 
 class TypeTemplateTest(unittest.TestCase):
     def test_correct_type(self):
         config = _root({'foo': set()})
-        valid = config['foo'].get(confit.TypeTemplate(set))
+        valid = config['foo'].get(confuse.TypeTemplate(set))
         self.assertEqual(valid, set())
 
     def test_incorrect_type(self):
         config = _root({'foo': dict()})
-        with self.assertRaises(confit.ConfigTypeError):
-            config['foo'].get(confit.TypeTemplate(set))
+        with self.assertRaises(confuse.ConfigTypeError):
+            config['foo'].get(confuse.TypeTemplate(set))
 
     def test_missing_required_value(self):
         config = _root({})
-        with self.assertRaises(confit.NotFoundError):
-            config['foo'].get(confit.TypeTemplate(set))
+        with self.assertRaises(confuse.NotFoundError):
+            config['foo'].get(confuse.TypeTemplate(set))
 
     def test_default_value(self):
         config = _root({})
-        valid = config['foo'].get(confit.TypeTemplate(set, set([1, 2])))
+        valid = config['foo'].get(confuse.TypeTemplate(set, set([1, 2])))
         self.assertEqual(valid, set([1, 2]))

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,4 +1,4 @@
-import confit
+import confuse
 import os
 from . import _root, unittest
 
@@ -10,7 +10,7 @@ class TypeCheckTest(unittest.TestCase):
 
     def test_str_type_incorrect(self):
         config = _root({'foo': 2})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             config['foo'].get(str)
 
     def test_int_type_correct(self):
@@ -20,7 +20,7 @@ class TypeCheckTest(unittest.TestCase):
 
     def test_int_type_incorrect(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             config['foo'].get(int)
 
 class BuiltInValidatorTest(unittest.TestCase):
@@ -30,7 +30,7 @@ class BuiltInValidatorTest(unittest.TestCase):
         self.assertEqual(value, os.path.join(os.getcwd(), 'foo', 'bar'))
 
     def test_as_filename_with_file_source(self):
-        source = confit.ConfigSource({'foo': 'foo/bar'},
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
                                      filename='/baz/config.yaml')
         config = _root(source)
         config.config_dir = lambda: '/config/path'
@@ -38,7 +38,7 @@ class BuiltInValidatorTest(unittest.TestCase):
         self.assertEqual(value, os.path.realpath('/config/path/foo/bar'))
 
     def test_as_filename_with_default_source(self):
-        source = confit.ConfigSource({'foo': 'foo/bar'},
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
                                      filename='/baz/config.yaml',
                                      default=True)
         config = _root(source)
@@ -48,7 +48,7 @@ class BuiltInValidatorTest(unittest.TestCase):
 
     def test_as_filename_wrong_type(self):
         config = _root({'foo': None})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             config['foo'].as_filename()
 
     def test_as_choice_correct(self):
@@ -58,7 +58,7 @@ class BuiltInValidatorTest(unittest.TestCase):
 
     def test_as_choice_error(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.ConfigValueError):
+        with self.assertRaises(confuse.ConfigValueError):
             config['foo'].as_choice(['foo', 'baz'])
 
     def test_as_choice_with_dict(self):
@@ -77,14 +77,14 @@ class BuiltInValidatorTest(unittest.TestCase):
         config = _root({'i': 2})
         config['i'].as_number()
 
-    @unittest.skipIf(confit.PY3, "long only present in Python 2")
+    @unittest.skipIf(confuse.PY3, "long only present in Python 2")
     def test_as_number_long_in_py2(self):
         config = _root({'l': long(3)})
         config['l'].as_number()
 
     def test_as_number_string(self):
         config = _root({'s': 'a'})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             config['s'].as_number()
 
     def test_as_str_seq_str(self):

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,4 +1,4 @@
-import confit
+import confuse
 import sys
 from . import _root, unittest
 
@@ -17,12 +17,12 @@ class SingleSourceTest(unittest.TestCase):
 
     def test_missing_key(self):
         config = _root({'foo': 'bar'})
-        with self.assertRaises(confit.NotFoundError):
+        with self.assertRaises(confuse.NotFoundError):
             config['baz'].get()
 
     def test_missing_index(self):
         config = _root({'l': ['foo', 'bar']})
-        with self.assertRaises(confit.NotFoundError):
+        with self.assertRaises(confuse.NotFoundError):
             config['l'][5].get()
 
     def test_dict_keys(self):
@@ -42,7 +42,7 @@ class SingleSourceTest(unittest.TestCase):
 
     def test_list_keys_error(self):
         config = _root({'l': ['foo', 'bar']})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             config['l'].keys()
 
     def test_dict_contents(self):
@@ -57,7 +57,7 @@ class SingleSourceTest(unittest.TestCase):
 
     def test_int_contents(self):
         config = _root({'n': 2})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             list(config['n'].all_contents())
 
 class ConverstionTest(unittest.TestCase):
@@ -71,7 +71,7 @@ class ConverstionTest(unittest.TestCase):
         value = str(config['foo'])
         self.assertEqual(value, '2')
 
-    @unittest.skipIf(confit.PY3, "unicode only present in Python 2")
+    @unittest.skipIf(confuse.PY3, "unicode only present in Python 2")
     def test_unicode_conversion_from_int(self):
         config = _root({'foo': 2})
         value = unicode(config['foo'])
@@ -120,7 +120,7 @@ class MultipleSourceTest(unittest.TestCase):
 
     def test_dict_access_missing(self):
         config = _root({'qux': 'bar'}, {'foo': 'baz'})
-        with self.assertRaises(confit.NotFoundError):
+        with self.assertRaises(confuse.NotFoundError):
             config['fred'].get()
 
     def test_list_access_shadowed(self):
@@ -135,7 +135,7 @@ class MultipleSourceTest(unittest.TestCase):
 
     def test_list_access_missing(self):
         config = _root({'l': ['a', 'b']}, {'l': ['c', 'd', 'e']})
-        with self.assertRaises(confit.NotFoundError):
+        with self.assertRaises(confuse.NotFoundError):
             config['l'][3].get()
 
     def test_access_dict_replaced(self):
@@ -190,7 +190,7 @@ class MultipleSourceTest(unittest.TestCase):
 
     def test_int_contents_error(self):
         config = _root({'foo': ['bar', 'baz']}, {'foo': 5})
-        with self.assertRaises(confit.ConfigTypeError):
+        with self.assertRaises(confuse.ConfigTypeError):
             list(config['foo'].all_contents())
 
     def test_list_and_dict_contents_concatenated(self):

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -1,14 +1,14 @@
-import confit
+import confuse
 import yaml
 from . import unittest, TempDir
 
 def load(s):
-    return yaml.load(s, Loader=confit.Loader)
+    return yaml.load(s, Loader=confuse.Loader)
 
 class ParseTest(unittest.TestCase):
     def test_dict_parsed_as_ordereddict(self):
         v = load("a: b\nc: d")
-        self.assertTrue(isinstance(v, confit.OrderedDict))
+        self.assertTrue(isinstance(v, confuse.OrderedDict))
         self.assertEqual(list(v), ['a', 'c'])
 
     def test_string_beginning_with_percent(self):
@@ -19,7 +19,7 @@ class FileParseTest(unittest.TestCase):
     def _parse_contents(self, contents):
         with TempDir() as temp:
             path = temp.sub('test_config.yaml', contents)
-            return confit.load_yaml(path)
+            return confuse.load_yaml(path)
 
     def test_load_file(self):
         v = self._parse_contents(b'foo: bar')
@@ -28,7 +28,7 @@ class FileParseTest(unittest.TestCase):
     def test_syntax_error(self):
         try:
             self._parse_contents(b':')
-        except confit.ConfigError as exc:
+        except confuse.ConfigError as exc:
             self.assertTrue('test_config.yaml' in exc.filename)
         else:
             self.fail('ConfigError not raised')
@@ -36,7 +36,7 @@ class FileParseTest(unittest.TestCase):
     def test_tab_indentation_error(self):
         try:
             self._parse_contents(b"foo:\n\tbar: baz")
-        except confit.ConfigError as exc:
+        except confuse.ConfigError as exc:
             self.assertTrue('found tab' in exc.args[0])
         else:
             self.fail('ConfigError not raised')


### PR DESCRIPTION
Before this package gets widely adopted, it would be a good idea to properly rename 'confit' to 'confuse'. This PR takes care of most of it; you will still need to rename the github repo and the readthedocs project.